### PR TITLE
Utilize a temporary build path

### DIFF
--- a/giftwrap/builder.py
+++ b/giftwrap/builder.py
@@ -25,15 +25,21 @@ class Builder(object):
         self._spec = spec
         self.settings = spec.settings
 
+    def _validate_settings(self):
+        raise NotImplementedError()
+
     def _build(self):
         raise NotImplementedError()
 
-    def _validate_settings(self):
+    def _cleanup(self):
         raise NotImplementedError()
 
     def build(self):
         self._validate_settings()
         self._build()
+
+    def cleanup(self):
+        self._cleanup()
 
 
 from giftwrap.builders.package_builder import PackageBuilder

--- a/giftwrap/builders/docker_builder.py
+++ b/giftwrap/builders/docker_builder.py
@@ -46,6 +46,7 @@ APT_REQUIRED_PACKAGES = [
     'python-pip',
     'build-essential'
 ]
+DEFAULT_SRC_PATH = '/opt/openstack'
 
 
 class DockerBuilder(Builder):
@@ -59,8 +60,10 @@ class DockerBuilder(Builder):
         super(DockerBuilder, self).__init__(spec)
 
     def _validate_settings(self):
-        if not self.settings.all_in_one:
-            LOG.warn("The Docker builder does not support all-in-one")
+        pass
+
+    def _cleanup(self):
+        pass
 
     def _get_prep_commands(self):
         commands = []
@@ -69,7 +72,6 @@ class DockerBuilder(Builder):
         return commands
 
     def _get_build_commands(self, src_path):
-
         commands = []
         commands.append('mkdir -p %s' % src_path)
 
@@ -119,7 +121,7 @@ class DockerBuilder(Builder):
         return template.render(template_vars)
 
     def _build(self):
-        src_path = '/tmp/build'
+        src_path = DEFAULT_SRC_PATH
         commands = self._get_prep_commands()
         commands += self._get_build_commands(src_path)
         commands += self._get_cleanup_commands(src_path)

--- a/giftwrap/package.py
+++ b/giftwrap/package.py
@@ -26,11 +26,12 @@ SUPPORTED_DISTROS = {
 
 class Package(object):
 
-    def __init__(self, name, version, path, overwrite=False,
-                 dependencies=None):
+    def __init__(self, name, version, build_path, install_path,
+                 overwrite=False, dependencies=None):
         self.name = name
         self.version = version
-        self.path = path
+        self.build_path = build_path
+        self.install_path = install_path
         self.overwrite = overwrite
         self.dependencies = dependencies
 
@@ -49,5 +50,6 @@ class Package(object):
             deps = '-d %s' % (' -d '.join(self.dependencies))
 
         # not wrapping in a try block - handled by caller
-        execute("fpm %s -s dir -t %s -n %s -v %s %s %s" %
-                (overwrite, target, self.name, self.version, deps, self.path))
+        execute("fpm %s -s dir -t %s -n %s -v %s %s %s" % (overwrite, target,
+                self.name, self.version, deps, self.install_path),
+                self.build_path)

--- a/giftwrap/settings.py
+++ b/giftwrap/settings.py
@@ -26,15 +26,14 @@ class Settings(object):
 
     def __init__(self, build_type=DEFAULT_BUILD_TYPE,
                  package_name_format=None, version=None,
-                 base_path=None, all_in_one=False,
-                 gerrit_dependencies=True, force_overwrite=False):
+                 base_path=None, gerrit_dependencies=True,
+                 force_overwrite=False):
         if not version:
             raise Exception("'version' is a required settings")
         self.build_type = build_type
         self._package_name_format = package_name_format
         self.version = version
         self._base_path = base_path
-        self.all_in_one = all_in_one
         self.gerrit_dependencies = gerrit_dependencies
         self.force_overwrite = force_overwrite
 

--- a/giftwrap/util.py
+++ b/giftwrap/util.py
@@ -60,3 +60,9 @@ def execute(command, cwd=None, exit=0):
                         (command, exitcode, out, err))
 
     return out
+
+
+def relative_pathify(path):
+    if path.startswith('/'):
+        return path[1:]
+    return path


### PR DESCRIPTION
Previously giftwrap was building packages directly in the destination
path. This often required sudo access to drop directories and files in
system paths.

In addition to just adding the code to build in a tempdir, add the
supporting code as well: cleanup, signal handling, etc.
