### PR TITLE
Add information about the git repo and limit depth

### DIFF
--- a/giftwrap/builders/docker_builder.py
+++ b/giftwrap/builders/docker_builder.py
@@ -79,9 +79,11 @@ class DockerBuilder(Builder):
                                 ' '.join(project.system_dependencies))
 
             project_src_path = os.path.join(src_path, project.name)
-            commands.append('git clone %s -b %s %s' % (project.giturl,
-                                                       project.gitref,
-                                                       project_src_path))
+            commands.append('git clone --depth 1 %s -b %s %s' %
+                            (project.giturl, project.gitref, project_src_path))
+            commands.append('COMMIT=`git rev-parse HEAD` && echo "%s $COMMIT" '
+                            '> %s/gitinfo' % (project.giturl,
+                                              project.install_path))
             commands.append('mkdir -p %s' %
                             os.path.dirname(project.install_path))
             commands.append('virtualenv --system-site-packages %s' %

--- a/giftwrap/builders/package_builder.py
+++ b/giftwrap/builders/package_builder.py
@@ -80,6 +80,11 @@ class PackageBuilder(Builder):
             repo = OpenstackGitRepo(project.giturl, project.gitref)
             repo.clone(project_src_path)
 
+            # tell package users where this came from
+            gitinfo_file = os.path.join(install_path, 'gitinfo')
+            with open(gitinfo_file, 'w') as fh:
+                fh.write("%s %s" % (project.giturl, repo.head.hexsha))
+
             # start building the virtualenv for the project
             LOG.info("Creating the virtualenv for '%s'", project.name)
             execute(project.venv_command, project.install_path)

--- a/giftwrap/openstack_git_repo.py
+++ b/giftwrap/openstack_git_repo.py
@@ -60,7 +60,7 @@ class OpenstackGitRepo(object):
 
     def clone(self, outdir):
         LOG.debug("Cloning '%s' to '%s'", self.url, outdir)
-        self._repo = Repo.clone_from(self.url, outdir, recursive=True)
+        self._repo = Repo.clone_from(self.url, outdir, recursive=True, depth=1)
         git = self._repo.git
         git.checkout(self.branch)
         self._invalidate_attrs()


### PR DESCRIPTION
Every package/image should contain information about where it came from.
Include a gitinfo file at the top of every project path, and in order to
save space (especially in Docker), limit git clone depth to 1.
