### PR TITLE
overwrite not always defined

### DIFF
--- a/giftwrap/package.py
+++ b/giftwrap/package.py
@@ -41,6 +41,7 @@ class Package(object):
                             distro)
         target = SUPPORTED_DISTROS[distro]
 
+        overwrite = ''
         if self.overwrite:
             overwrite = '-f'
 


### PR DESCRIPTION
Add the local variable 'overwrite' with a default value.
