### PR TITLE
Allow specification of build type from the CLI

### DIFF
--- a/giftwrap/build_spec.py
+++ b/giftwrap/build_spec.py
@@ -22,10 +22,14 @@ from giftwrap.settings import Settings
 
 class BuildSpec(object):
 
-    def __init__(self, manifest, version):
+    def __init__(self, manifest, version, build_type=None):
         self._manifest = yaml.load(manifest)
         self.version = version
-        self.settings = Settings.factory(self._manifest['settings'])
+        self.build_type = build_type
+        manifest_settings = self._manifest['settings']
+        if build_type:
+            manifest_settings['build_type'] = build_type
+        self.settings = Settings.factory(manifest_settings)
         self.projects = self._render_projects()
 
     def _render_projects(self):

--- a/giftwrap/shell.py
+++ b/giftwrap/shell.py
@@ -44,7 +44,7 @@ def build(args):
         with open(args.manifest, 'r') as fh:
             manifest = fh.read()
 
-        buildspec = BuildSpec(manifest, args.version)
+        buildspec = BuildSpec(manifest, args.version, args.type)
         builder = giftwrap.builder.create_builder(buildspec)
         builder.build()
     except Exception as e:
@@ -65,6 +65,7 @@ def main():
                                          description='build giftwrap packages')
     build_subcmd.add_argument('-m', '--manifest', required=True)
     build_subcmd.add_argument('-v', '--version')
+    build_subcmd.add_argument('-t', '--type', choices=('docker', 'package'))
     build_subcmd.set_defaults(func=build)
 
     args = parser.parse_args()


### PR DESCRIPTION
There may be times when you want ot override the build type specified
in the manifest. This flag allows you to do do.
