### PR TITLE
Address broken package building due to tempdirs

### DIFF
--- a/giftwrap/builders/package_builder.py
+++ b/giftwrap/builders/package_builder.py
@@ -101,6 +101,7 @@ class PackageBuilder(Builder):
             # now build the package
             pkg = Package(project.package_name, project.version, build_path,
                           relative_pathify(project.install_path),
+                          spec.settings.output_dir,
                           spec.settings.force_overwrite,
                           project.system_dependencies)
             pkg.build()

--- a/giftwrap/package.py
+++ b/giftwrap/package.py
@@ -14,6 +14,7 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 
+import os
 import platform
 
 from giftwrap.util import execute
@@ -26,12 +27,13 @@ SUPPORTED_DISTROS = {
 
 class Package(object):
 
-    def __init__(self, name, version, build_path, install_path,
+    def __init__(self, name, version, build_path, install_path, output_dir,
                  overwrite=False, dependencies=None):
         self.name = name
         self.version = version
         self.build_path = build_path
         self.install_path = install_path
+        self.output_dir = output_dir
         self.overwrite = overwrite
         self.dependencies = dependencies
 
@@ -50,7 +52,10 @@ class Package(object):
         if self.dependencies:
             deps = '-d %s' % (' -d '.join(self.dependencies))
 
+        if not os.path.exists(self.output_dir):
+            os.makedirs(self.output_dir)
+
         # not wrapping in a try block - handled by caller
-        execute("fpm %s -s dir -t %s -n %s -v %s %s %s" % (overwrite, target,
-                self.name, self.version, deps, self.install_path),
-                self.build_path)
+        execute("fpm %s -s dir -t %s -n %s -v %s -C %s %s %s" % (overwrite,
+                target, self.name, self.version, self.build_path, deps,
+                self.install_path), self.output_dir)

--- a/giftwrap/settings.py
+++ b/giftwrap/settings.py
@@ -14,6 +14,8 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 
+import os
+
 DEFAULT_BUILD_TYPE = 'package'
 
 
@@ -27,7 +29,7 @@ class Settings(object):
     def __init__(self, build_type=DEFAULT_BUILD_TYPE,
                  package_name_format=None, version=None,
                  base_path=None, gerrit_dependencies=True,
-                 force_overwrite=False):
+                 force_overwrite=False, output_dir=None):
         if not version:
             raise Exception("'version' is a required settings")
         self.build_type = build_type
@@ -36,6 +38,7 @@ class Settings(object):
         self._base_path = base_path
         self.gerrit_dependencies = gerrit_dependencies
         self.force_overwrite = force_overwrite
+        self._output_dir = output_dir
 
     @property
     def package_name_format(self):
@@ -44,6 +47,12 @@ class Settings(object):
     @property
     def base_path(self):
         return self._get_setting('base_path')
+
+    @property
+    def output_dir(self):
+        if not self._output_dir:
+            self._output_dir = os.getcwd()
+        return self._output_dir
 
     def _get_setting(self, setting_name):
         setting = object.__getattribute__(self, '_%s' % setting_name)


### PR DESCRIPTION
Recently, support was added to build packages in temporary directories.
This inadvertently led to a bug wherein when the build is finished, and
the tempdir is removed, the packages were removed with it.

This fix adds the output_dir setting.  If set, the packages will be
output to the directory specified, else to the cwd of the giftwrap
process.
