### PR TITLE
Add configuration data to packages

### DIFF
--- a/giftwrap/builders/package_builder.py
+++ b/giftwrap/builders/package_builder.py
@@ -100,6 +100,17 @@ class PackageBuilder(Builder):
             deps = " ".join(project.pip_dependencies)
             execute("%s install %s" % (venv_pip_path, deps))
 
+            if spec.settings.include_config:
+                src_config = os.path.join(project_src_path, 'etc')
+                dest_config = os.path.join(install_path, 'etc')
+                if not os.path.exists(src_config):
+                    LOG.warning("Project configuration does not seem to exist "
+                                "in source repo '%s'. Skipping.", project.name)
+                else:
+                    LOG.debug("Copying config from '%s' to '%s'", src_config, 
+                              dest_config)
+                    shutil.copytree(src_config, dest_config)
+
             if spec.settings.gerrit_dependencies:
                 self._install_gerrit_dependencies(repo, project, install_path)
 

--- a/giftwrap/builders/package_builder.py
+++ b/giftwrap/builders/package_builder.py
@@ -107,7 +107,7 @@ class PackageBuilder(Builder):
                     LOG.warning("Project configuration does not seem to exist "
                                 "in source repo '%s'. Skipping.", project.name)
                 else:
-                    LOG.debug("Copying config from '%s' to '%s'", src_config, 
+                    LOG.debug("Copying config from '%s' to '%s'", src_config,
                               dest_config)
                     shutil.copytree(src_config, dest_config)
 

--- a/giftwrap/settings.py
+++ b/giftwrap/settings.py
@@ -29,7 +29,7 @@ class Settings(object):
     def __init__(self, build_type=DEFAULT_BUILD_TYPE,
                  package_name_format=None, version=None,
                  base_path=None, gerrit_dependencies=True,
-                 force_overwrite=False, output_dir=None):
+                 force_overwrite=False, output_dir=None, include_config=True):
         if not version:
             raise Exception("'version' is a required settings")
         self.build_type = build_type
@@ -39,6 +39,7 @@ class Settings(object):
         self.gerrit_dependencies = gerrit_dependencies
         self.force_overwrite = force_overwrite
         self._output_dir = output_dir
+        self.include_config = include_config
 
     @property
     def package_name_format(self):


### PR DESCRIPTION
This change copies $project/etc into the resulting packages. This is useful
for things like no managing rootwrap configs, etc. This is managed with the
new setting 'include_config.'