### PR TITLE
Allow overriding install_path format

### DIFF
--- a/giftwrap/openstack_project.py
+++ b/giftwrap/openstack_project.py
@@ -14,7 +14,6 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 
-import os
 import urlparse
 
 from jinja2 import Environment
@@ -93,8 +92,7 @@ class OpenstackProject(object):
     @property
     def install_path(self):
         if not self._install_path:
-            base_path = self._render_from_settings('base_path')
-            self._install_path = os.path.join(base_path, self.name)
+            self._install_path = self._render_from_settings('install_path')
         return self._install_path
 
     @property

--- a/giftwrap/settings.py
+++ b/giftwrap/settings.py
@@ -23,12 +23,13 @@ class Settings(object):
 
     DEFAULTS = {
         'package_name_format': 'openstack-{{ project.name }}',
-        'base_path': '/opt/openstack'
+        'base_path': '/opt/openstack',
+        'install_path': '{{ base_path }}/{{ project.name }}'
     }
 
     def __init__(self, build_type=DEFAULT_BUILD_TYPE,
                  package_name_format=None, version=None,
-                 base_path=None, gerrit_dependencies=True,
+                 base_path=None, install_path=None, gerrit_dependencies=True,
                  force_overwrite=False, output_dir=None, include_config=True):
         if not version:
             raise Exception("'version' is a required settings")
@@ -36,6 +37,7 @@ class Settings(object):
         self._package_name_format = package_name_format
         self.version = version
         self._base_path = base_path
+        self._install_path = install_path
         self.gerrit_dependencies = gerrit_dependencies
         self.force_overwrite = force_overwrite
         self._output_dir = output_dir
@@ -48,6 +50,10 @@ class Settings(object):
     @property
     def base_path(self):
         return self._get_setting('base_path')
+
+    @property
+    def install_path(self):
+        return self._get_setting('install_path')
 
     @property
     def output_dir(self):


### PR DESCRIPTION
Normally the install_path defaults to base_path/project_name.  If you wanted
to do anything else, like base_path/project_name-version you'd have to hard
code the version on the install_path variable for every project.  This allows
setting install_path as a templated top level setting.  The default reproduces
the existing base_path/project_name behavior.