### PR TITLE
Fix pep8 failures

### DIFF
--- a/giftwrap/builders/docker_builder.py
+++ b/giftwrap/builders/docker_builder.py
@@ -15,6 +15,7 @@
 # License for the specific language governing permissions and limitations
 
 import docker
+import jinja2
 import json
 import logging
 import os
@@ -24,8 +25,6 @@ import tempfile
 from giftwrap.builder import Builder
 
 LOG = logging.getLogger(__name__)
-
-import jinja2
 
 DEFAULT_TEMPLATE_FILE = os.path.join(os.path.dirname(
                                      os.path.dirname(__file__)),

--- a/giftwrap/builders/package_builder.py
+++ b/giftwrap/builders/package_builder.py
@@ -19,15 +19,13 @@ import os
 import shutil
 import tempfile
 
+from giftwrap.builder import Builder
 from giftwrap.gerrit import GerritReview
 from giftwrap.openstack_git_repo import OpenstackGitRepo
 from giftwrap.package import Package
 from giftwrap.util import execute
 
 LOG = logging.getLogger(__name__)
-
-
-from giftwrap.builder import Builder
 
 
 class PackageBuilder(Builder):

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ downloadcache = {toxworkdir}/_download
 
 [testenv:pep8]
 commands =
-    flake8 {posargs} {toxinidir}/giftwrap
+    flake8 {posargs} --ignore=E402 {toxinidir}/giftwrap
 
 [testenv:venv]
 commands = {posargs}


### PR DESCRIPTION
pep8 with 1.6.x is now failing as it wants all imports at the
beginning of the file. Unfortunately, this does not work for us in
all circumstances. Therefore, ignore E402 and fix the E402's where
it actually makes sense.