### PR TITLE
ensure that ap-cach update is properly run

### DIFF
--- a/scripts/prepare_debian.sh
+++ b/scripts/prepare_debian.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-apt-get -yqq update
-apt-get dist-upgrade -y
-apt-get install -yqq build-essential ruby1.9.1-dev git python-pip python-dev python-virtualenv libxml2-dev libxslt-dev libffi-dev libmysqlclient-dev libpq-dev libsqlite3-dev
+apt-get -yqq update && apt-get dist-upgrade -y
+apt-get -yqq update && apt-get install -yqq build-essential ruby1.9.1-dev git python-pip python-dev python-virtualenv libxml2-dev libxslt-dev libffi-dev libmysqlclient-dev libpq-dev libsqlite3-dev


### PR DESCRIPTION
not sure why, but it seems like apt-cache update can be performed
asyncronously from the dist-upgrade and apt-get install. So, make
sure we get it done right.