### PR TITLE
Always ensure that we have latest pip/setuptools

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -58,6 +58,16 @@ Vagrant.configure('2') do |config|
 
     gem install --no-ri --no-rdoc fpm
     cd /vagrant
+
+    GET_PIP_MD5='add41078298d8111714c6b87636714f5'
+    wget -q -O /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py
+    if ! md5sum /tmp/get-pip.py | grep -q $GET_PIP_MD5; then
+        echo "pip installation could not be verified. Quitting"
+        exit -1
+    fi
+    python /tmp/get-pip.py
+    pip install -U setuptools     
+    
     python setup.py install
     giftwrap build -m #{GIFTWRAP_MANIFEST} #{GIFTWRAP_ARGS}
 

--- a/scripts/prepare_debian.sh
+++ b/scripts/prepare_debian.sh
@@ -2,3 +2,4 @@
 
 apt-get -yqq update && apt-get dist-upgrade -y
 apt-get -yqq update && apt-get install -yqq build-essential ruby1.9.1-dev git python-pip python-dev python-virtualenv libxml2-dev libxslt-dev libffi-dev libmysqlclient-dev libpq-dev libsqlite3-dev
+apt-get remove -y python-pip python-setuptools


### PR DESCRIPTION
We always want to be sure to have the latest pip and setuptools, so
remove them if present in apt and then install them in the Vagrantfile
itself.