### PR TITLE
Fix nested jinja tags bug

### DIFF
--- a/giftwrap/build_spec.py
+++ b/giftwrap/build_spec.py
@@ -27,6 +27,8 @@ class BuildSpec(object):
         self.version = version
         self.build_type = build_type
         manifest_settings = self._manifest['settings']
+        if version:
+            manifest_settings['version'] = version
         if build_type:
             manifest_settings['build_type'] = build_type
         self.settings = Settings.factory(manifest_settings)

--- a/giftwrap/openstack_project.py
+++ b/giftwrap/openstack_project.py
@@ -86,6 +86,7 @@ class OpenstackProject(object):
 
     def _template_vars(self):
         template_vars = {'project': self}
+        template_vars['settings'] = self._settings
         for var in TEMPLATE_VARS:
             template_vars[var] = object.__getattribute__(self, var)
         return template_vars
@@ -115,8 +116,14 @@ class OpenstackProject(object):
         setting = getattr(self._settings, setting_name)
         env = Environment()
         env.add_extension('jinja2.ext.autoescape')
-        t = env.from_string(setting)
-        return t.render(self._template_vars())
+        result = setting
+        while True:
+            t = env.from_string(result)
+            newresult = t.render(self._template_vars())
+            if newresult == result:
+                break
+            result = newresult
+        return result
 
     @staticmethod
     def factory(settings, project_dict, version):

--- a/giftwrap/settings.py
+++ b/giftwrap/settings.py
@@ -24,7 +24,7 @@ class Settings(object):
     DEFAULTS = {
         'package_name_format': 'openstack-{{ project.name }}',
         'base_path': '/opt/openstack',
-        'install_path': '{{ base_path }}/{{ project.name }}'
+        'install_path': '{{ settings.base_path }}/{{ project.name }}'
     }
 
     def __init__(self, build_type=DEFAULT_BUILD_TYPE,


### PR DESCRIPTION
Unfortunately, there was an issue where {{ base_path }} was evaluating
to an empty string following merge of:

https://github.com/blueboxgroup/giftwrap/pull/20

This introduces a loop over jinja rendering that will continue until it
is done.