### PR TITLE
Only use copytree when dest doesnt exist

### DIFF
--- a/giftwrap/builders/package_builder.py
+++ b/giftwrap/builders/package_builder.py
@@ -108,7 +108,10 @@ class PackageBuilder(Builder):
                 else:
                     LOG.debug("Copying config from '%s' to '%s'", src_config,
                               dest_config)
-                    shutil.copytree(src_config, dest_config)
+                    if not os.path.exists(dest_config):
+                        shutil.copytree(src_config, dest_config)
+                    else:
+                        shutil.copy2(src_config, dest_config)
 
             if spec.settings.gerrit_dependencies:
                 self._install_gerrit_dependencies(repo, project, install_path)


### PR DESCRIPTION
shutil.copytree will fail if the destination directory already exists.
It may exist when other dependencies place an entry there. Therefore,
if it already exists, use shutil.copy2 instead.