### PR TITLE
Switch from python setup.py to pip for install

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -77,7 +77,7 @@ Vagrant.configure('2') do |config|
     pip install -U setuptools     
     
     export PATH=/usr/local/bin/:$PATH
-    python setup.py install
+    pip install .
     giftwrap build -m #{GIFTWRAP_MANIFEST} #{GIFTWRAP_ARGS}
 
     if [ ! -z "#{GIFTWRAP_POSTBUILD_SCRIPT}" ]; then

--- a/giftwrap/builders/docker_builder.py
+++ b/giftwrap/builders/docker_builder.py
@@ -92,15 +92,13 @@ class DockerBuilder(Builder):
 
             project_bin_path = os.path.join(project.install_path, 'bin')
             self._paths.append(project_bin_path)
-            venv_python_path = os.path.join(project_bin_path, 'python')
             venv_pip_path = os.path.join(project_bin_path, 'pip')
 
             if project.pip_dependencies:
                 commands.append("%s install %s" % (venv_pip_path,
                                 ' '.join(project.pip_dependencies)))
-            commands.append('cd %s && %s setup.py install && cd -' %
-                            (project_src_path, venv_python_path))
-            commands.append("%s install pbr" % venv_pip_path)
+            commands.append("%s install %s" % (venv_pip_path,
+                                               project_src_path))
 
         return commands
 

--- a/giftwrap/builders/package_builder.py
+++ b/giftwrap/builders/package_builder.py
@@ -94,7 +94,6 @@ class PackageBuilder(Builder):
 
             # install into the virtualenv
             LOG.info("Installing '%s' to the virtualenv", project.name)
-            venv_python_path = os.path.join(install_path, 'bin/python')
             venv_pip_path = os.path.join(install_path, 'bin/pip')
 
             deps = " ".join(project.pip_dependencies)
@@ -114,8 +113,7 @@ class PackageBuilder(Builder):
             if spec.settings.gerrit_dependencies:
                 self._install_gerrit_dependencies(repo, project, install_path)
 
-            execute("%s setup.py install" % venv_python_path, project_src_path)
-            execute("%s install pbr" % venv_pip_path)
+            execute("%s install %s" % (venv_pip_path, project_src_path))
 
             # now build the package
             pkg = Package(project.package_name, project.version,


### PR DESCRIPTION
Using python setup.py install with a PBR managed system doesn't work. It
hasn't been supported for a while
(http://lists.openstack.org/pipermail/openstack-dev/2013-September/015525.html
and
https://openstack.nimeyo.com/42989/openstack-dev-pbr-support-for-python-setup-py-install).
It's now breaking in our CI due to not installing the required deps,
such as the requests module. By using pip install we get all that we
want, as upstream for PBR suggests.