### PR TITLE
Ensure latest pip inside the venv

### DIFF
--- a/giftwrap/builders/docker_builder.py
+++ b/giftwrap/builders/docker_builder.py
@@ -94,6 +94,8 @@ class DockerBuilder(Builder):
             self._paths.append(project_bin_path)
             venv_pip_path = os.path.join(project_bin_path, 'pip')
 
+            commands.append("%s install -U pip" % venv_pip_path)
+
             if project.pip_dependencies:
                 commands.append("%s install %s" % (venv_pip_path,
                                 ' '.join(project.pip_dependencies)))

--- a/giftwrap/builders/package_builder.py
+++ b/giftwrap/builders/package_builder.py
@@ -92,9 +92,13 @@ class PackageBuilder(Builder):
             LOG.info("Creating the virtualenv for '%s'", project.name)
             execute(project.venv_command, install_path)
 
+            # update pip in the virtualenv
+            LOG.info("Updating pip in the virtualenv for '%s'", project.name)
+            venv_pip_path = os.path.join(install_path, 'bin/pip')
+            execute("%s install -U pip" % venv_pip_path)
+
             # install into the virtualenv
             LOG.info("Installing '%s' to the virtualenv", project.name)
-            venv_pip_path = os.path.join(install_path, 'bin/pip')
 
             deps = " ".join(project.pip_dependencies)
             execute("%s install %s" % (venv_pip_path, deps))


### PR DESCRIPTION
Earlier pip can struggle with openstack dependency trees, so make sure
we have the latest.