### PR TITLE
Add parallel builds

### DIFF
--- a/giftwrap/build_spec.py
+++ b/giftwrap/build_spec.py
@@ -22,7 +22,7 @@ from giftwrap.settings import Settings
 
 class BuildSpec(object):
 
-    def __init__(self, manifest, version, build_type=None):
+    def __init__(self, manifest, version, build_type=None, parallel=True):
         self._manifest = yaml.load(manifest)
         self.version = version
         self.build_type = build_type
@@ -31,6 +31,7 @@ class BuildSpec(object):
             manifest_settings['version'] = version
         if build_type:
             manifest_settings['build_type'] = build_type
+        manifest_settings['parallel_build'] = parallel
         self.settings = Settings.factory(manifest_settings)
         self.projects = self._render_projects()
 

--- a/giftwrap/settings.py
+++ b/giftwrap/settings.py
@@ -30,7 +30,8 @@ class Settings(object):
     def __init__(self, build_type=DEFAULT_BUILD_TYPE,
                  package_name_format=None, version=None,
                  base_path=None, install_path=None, gerrit_dependencies=True,
-                 force_overwrite=False, output_dir=None, include_config=True):
+                 force_overwrite=False, output_dir=None, include_config=True,
+                 parallel_build=True):
         if not version:
             raise Exception("'version' is a required settings")
         self.build_type = build_type
@@ -42,6 +43,7 @@ class Settings(object):
         self.force_overwrite = force_overwrite
         self._output_dir = output_dir
         self.include_config = include_config
+        self.parallel_build = parallel_build
 
     @property
     def package_name_format(self):

--- a/giftwrap/shell.py
+++ b/giftwrap/shell.py
@@ -46,7 +46,7 @@ def build(args):
         with open(args.manifest, 'r') as fh:
             manifest = fh.read()
 
-        buildspec = BuildSpec(manifest, args.version, args.type)
+        buildspec = BuildSpec(manifest, args.version, args.type, args.parallel)
         builder = BuilderFactory.create_builder(args.type, buildspec)
 
         def _signal_handler(*args):
@@ -80,6 +80,8 @@ def main():
     build_subcmd.add_argument('-v', '--version')
     build_subcmd.add_argument('-t', '--type', choices=('docker', 'package'),
                               required=True)
+    build_subcmd.add_argument('-s', '--synchronous', dest='parallel',
+                              action='store_false')
     build_subcmd.set_defaults(func=build)
 
     args = parser.parse_args()


### PR DESCRIPTION
This change runs builds in parallel. By default all projects run
simultaneously unless --synchronous is specified. This should speed
up build times dramatically.