### PR TITLE
Support postinstall python dependencies

### DIFF
--- a/giftwrap/builders/__init__.py
+++ b/giftwrap/builders/__init__.py
@@ -71,6 +71,9 @@ class Builder(object):
 
         self._install_project(project.install_path, src_clone_dir)
 
+        if project.postinstall_dependencies:
+            self._install_postinstall_dependencies(project)
+
         # finish up
         self._finalize_project_build(project)
 
@@ -130,6 +133,10 @@ class Builder(object):
 
     @abstractmethod
     def _install_project(self, venv_path, src_clone_dir):
+        return
+
+    @abstractmethod
+    def _install_postinstall_dependencies(self, project):
         return
 
     @abstractmethod

--- a/giftwrap/builders/docker_builder.py
+++ b/giftwrap/builders/docker_builder.py
@@ -97,6 +97,11 @@ class DockerBuilder(Builder):
         pip_path = self._get_venv_pip_path(venv_path)
         self._execute("%s install %s" % (pip_path, src_clone_dir))
 
+    def _install_postinstall_dependencies(self, project):
+        pip_path = self._get_venv_pip_path(project.install_path)
+        dependencies = " ".join(project.postinstall_dependencies)
+        self._execute("%s install %s" % (pip_path, dependencies))
+
     def _finalize_project_build(self, project):
         self._commands.append("rm -rf %s" % self._temp_dir)
         for command in self._commands:

--- a/giftwrap/builders/package_builder.py
+++ b/giftwrap/builders/package_builder.py
@@ -88,6 +88,11 @@ class PackageBuilder(Builder):
         pip_path = self._get_venv_pip_path(venv_path)
         self._execute("%s install %s" % (pip_path, src_clone_dir))
 
+    def _install_postinstall_dependencies(self, project):
+        pip_path = self._get_venv_pip_path(project.install_path)
+        dependencies = " ".join(project.postinstall_dependencies)
+        self._execute("%s install %s" % (pip_path, dependencies))
+
     def _finalize_project_build(self, project):
         # build the package
         pkg = Package(project.package_name, project.version,

--- a/giftwrap/openstack_project.py
+++ b/giftwrap/openstack_project.py
@@ -34,7 +34,8 @@ class OpenstackProject(object):
     def __init__(self, settings, name, version=None, gitref=None, giturl=None,
                  gitdepth=1, venv_command=None, install_command=None,
                  install_path=None, package_name=None, stackforge=False,
-                 system_dependencies=[], pip_dependencies=[]):
+                 system_dependencies=[], pip_dependencies=[],
+                 postinstall_dependencies=[]):
         self._settings = settings
         self.name = name
         self._version = version
@@ -49,6 +50,7 @@ class OpenstackProject(object):
         self._git_path = None
         self.system_dependencies = system_dependencies
         self.pip_dependencies = pip_dependencies
+        self.postinstall_dependencies = postinstall_dependencies
 
     @property
     def version(self):


### PR DESCRIPTION
There are cases where you would like for a Python module to be
installed *after* the project itself has been installed. This is now
possible with project.postinstall_dependencies.