### PR TITLE
Docker builds need to be synchronous

### DIFF
--- a/giftwrap/build_spec.py
+++ b/giftwrap/build_spec.py
@@ -31,6 +31,8 @@ class BuildSpec(object):
             manifest_settings['version'] = version
         if build_type:
             manifest_settings['build_type'] = build_type
+        if build_type == 'docker':
+            parallel = False
         manifest_settings['parallel_build'] = parallel
         self.settings = Settings.factory(manifest_settings)
         self.projects = self._render_projects()


### PR DESCRIPTION
There is no point in making Docker builds "parallel" as they are
executed by way of a docker build.