### PR TITLE
Install pip dependencies iteratively

### DIFF
--- a/giftwrap/builders/docker_builder.py
+++ b/giftwrap/builders/docker_builder.py
@@ -84,7 +84,8 @@ class DockerBuilder(Builder):
 
     def _install_pip_dependencies(self, venv_path, dependencies):
         pip_path = self._get_venv_pip_path(venv_path)
-        self._execute("%s install %s" % (pip_path, dependencies))
+        for dependency in dependencies:
+            self._execute("%s install %s" % (pip_path, dependency))
 
     def _copy_sample_config(self, src_clone_dir, project):
         src_config = os.path.join(src_clone_dir, 'etc')
@@ -96,11 +97,6 @@ class DockerBuilder(Builder):
     def _install_project(self, venv_path, src_clone_dir):
         pip_path = self._get_venv_pip_path(venv_path)
         self._execute("%s install %s" % (pip_path, src_clone_dir))
-
-    def _install_postinstall_dependencies(self, project):
-        pip_path = self._get_venv_pip_path(project.install_path)
-        dependencies = " ".join(project.postinstall_dependencies)
-        self._execute("%s install %s" % (pip_path, dependencies))
 
     def _finalize_project_build(self, project):
         self._commands.append("rm -rf %s" % self._temp_dir)

--- a/giftwrap/builders/package_builder.py
+++ b/giftwrap/builders/package_builder.py
@@ -70,7 +70,8 @@ class PackageBuilder(Builder):
 
     def _install_pip_dependencies(self, venv_path, dependencies):
         pip_path = self._get_venv_pip_path(venv_path)
-        self._execute("%s install %s" % (pip_path, dependencies))
+        for dependency in dependencies:
+            self._execute("%s install %s" % (pip_path, dependency))
 
     def _copy_sample_config(self, src_clone_dir, project):
         src_config = os.path.join(src_clone_dir, 'etc')
@@ -87,11 +88,6 @@ class PackageBuilder(Builder):
     def _install_project(self, venv_path, src_clone_dir):
         pip_path = self._get_venv_pip_path(venv_path)
         self._execute("%s install %s" % (pip_path, src_clone_dir))
-
-    def _install_postinstall_dependencies(self, project):
-        pip_path = self._get_venv_pip_path(project.install_path)
-        dependencies = " ".join(project.postinstall_dependencies)
-        self._execute("%s install %s" % (pip_path, dependencies))
 
     def _finalize_project_build(self, project):
         # build the package


### PR DESCRIPTION
Installing pip dependencies interatively (vs. concurrently) provides
for interesting manifest syntax. For example, one could specify
an index-url along side a dependency without affecting the other
dependencies in the list.