### PR TITLE
Fix git depth issues

### DIFF
--- a/giftwrap/builders/package_builder.py
+++ b/giftwrap/builders/package_builder.py
@@ -61,7 +61,7 @@ class PackageBuilder(Builder):
 
     def _clone_project(self, giturl, name, gitref, depth, path):
         LOG.info("Fetching source code for '%s'", name)
-        repo = OpenstackGitRepo(giturl, name, gitref, depth)
+        repo = OpenstackGitRepo(giturl, name, gitref, depth=depth)
         repo.clone(path)
         return repo
 

--- a/giftwrap/openstack_project.py
+++ b/giftwrap/openstack_project.py
@@ -32,7 +32,7 @@ TEMPLATE_VARS = ('name', 'version', 'gitref', 'stackforge')
 class OpenstackProject(object):
 
     def __init__(self, settings, name, version=None, gitref=None, giturl=None,
-                 gitdepth=1, venv_command=None, install_command=None,
+                 gitdepth=None, venv_command=None, install_command=None,
                  install_path=None, package_name=None, stackforge=False,
                  system_dependencies=[], pip_dependencies=[],
                  postinstall_dependencies=[]):


### PR DESCRIPTION
Defaulting a getdepth to 1 makes it difficult to switch branches if
the branch is not available in the shallow clone, so make this
optional. Also, instantiate OpenstackGitRepo properly: depth is not
the fourth parameter.