### PR TITLE
Add ability to extend builders via builder drivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+2.1.0
+-----
+- feature: add builder drivers using stevedore

--- a/giftwrap/shell.py
+++ b/giftwrap/shell.py
@@ -19,7 +19,7 @@ import logging
 import signal
 import sys
 
-from giftwrap.builders import BuilderFactory
+from giftwrap.builders import Builder, BuilderFactory
 from giftwrap.build_spec import BuildSpec
 from giftwrap.color import ColorStreamHandler
 
@@ -80,7 +80,7 @@ def main():
                                          description='build giftwrap packages')
     build_subcmd.add_argument('-m', '--manifest', required=True)
     build_subcmd.add_argument('-v', '--version')
-    build_subcmd.add_argument('-t', '--type', choices=('docker', 'package'),
+    build_subcmd.add_argument('-t', '--type', choices=Builder.builder_names(),
                               required=True)
     build_subcmd.add_argument('-s', '--synchronous', dest='parallel',
                               action='store_false')

--- a/giftwrap/tests/test_builder.py
+++ b/giftwrap/tests/test_builder.py
@@ -15,20 +15,25 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import copy
 import unittest2 as unittest
 
 from giftwrap.builders import Builder, BUILDER_DRIVER_NAMESPACE
 from stevedore import extension
 
+BASE_DRIVERS = set(['docker', 'package'])
+
 
 class TestBuilder(unittest.TestCase):
 
     def test_default_drivers(self):
-        drivers = Builder.builder_names()
-        self.assertEqual(drivers, ['docker', 'package'])
+        drivers = set(Builder.builder_names())
+        self.assertEqual(drivers, BASE_DRIVERS)
 
     def test_additional_drivers(self):
         em = extension.ExtensionManager(BUILDER_DRIVER_NAMESPACE)
         em.extensions.append(extension.Extension('test', None, None, None))
-        drivers = Builder.builder_names(em)
-        self.assertEqual(drivers, ['docker', 'package', 'test'])
+        drivers = set(Builder.builder_names(em))
+        base_drivers = copy.copy(BASE_DRIVERS)
+        base_drivers.add('test')
+        self.assertEqual(drivers, base_drivers)

--- a/giftwrap/tests/test_builder.py
+++ b/giftwrap/tests/test_builder.py
@@ -1,0 +1,34 @@
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+
+# Copyright 2015, Craig Tracey
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import unittest2 as unittest
+
+from giftwrap.builders import Builder, BUILDER_DRIVER_NAMESPACE
+from stevedore import extension
+
+
+class TestBuilder(unittest.TestCase):
+
+    def test_default_drivers(self):
+        drivers = Builder.builder_names()
+        self.assertEqual(drivers, ['docker', 'package'])
+
+    def test_additional_drivers(self):
+        em = extension.ExtensionManager(BUILDER_DRIVER_NAMESPACE)
+        em.extensions.append(extension.Extension('test', None, None, None))
+        drivers = Builder.builder_names(em)
+        self.assertEqual(drivers, ['docker', 'package', 'test'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ requests
 pygerrit
 docker-py
 virtualenv
+stevedore

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = giftwrap
-version = 2.0.0
+version = 2.1.0
 summary = giftwrap - A tool to build full-stack native system packages.
 description-file =
     README.md
@@ -22,6 +22,10 @@ setup-hooks =
 [entry_points]
 console_scripts =
     giftwrap = giftwrap.shell:main
+
+giftwrap.builder.drivers =
+    package = giftwrap.builders.package_builder:PackageBuilder
+    docker = giftwrap.builders.docker_builder:DockerBuilder
 
 [files]
 packages =


### PR DESCRIPTION
There are times where you may want to extend or modify the way that
giftwrap builds packages. Short of submitting a pull request or
(worse) forking the repository, there was no easy way to do so.

This change introduces builder drivers with stevedore. By merely adding
entry points in the 'giftwrap.builder.drivers', additional
implementations are now possible.