### PR TITLE
Add quotes to package install

### DIFF
--- a/giftwrap/openstack_project.py
+++ b/giftwrap/openstack_project.py
@@ -24,7 +24,7 @@ DEFAULT_GITURL = {
     'stackforge': 'https://github.com/stackforge/'
 }
 DEFAULT_VENV_COMMAND = "virtualenv --no-wheel ."
-DEFAULT_INSTALL_COMMAND = "./bin/pip install %s"  # noqa
+DEFAULT_INSTALL_COMMAND = "./bin/pip install '%s'"  # noqa
 
 TEMPLATE_VARS = ('name', 'version', 'gitref', 'stackforge')
 


### PR DESCRIPTION
postinstall_dependencies (and probably others) need to have the version
specified with == otherwise the command fails due to < and > being known
as redirects.  This adds quotes round the package name, so that bash
doesn't do that.