### PR TITLE
Add --projects to specify which projects to build

### DIFF
--- a/giftwrap/build_spec.py
+++ b/giftwrap/build_spec.py
@@ -22,7 +22,8 @@ from giftwrap.settings import Settings
 
 class BuildSpec(object):
 
-    def __init__(self, manifest, version, build_type=None, parallel=True):
+    def __init__(self, manifest, version, build_type=None, parallel=True,
+                 limit_projects=None):
         self._manifest = yaml.load(manifest)
         self.version = version
         self.build_type = build_type
@@ -35,13 +36,14 @@ class BuildSpec(object):
             parallel = False
         manifest_settings['parallel_build'] = parallel
         self.settings = Settings.factory(manifest_settings)
-        self.projects = self._render_projects()
+        self.projects = self._render_projects(limit_projects)
 
-    def _render_projects(self):
+    def _render_projects(self, limit_projects):
         projects = []
         if 'projects' in self._manifest:
             for project in self._manifest['projects']:
-                projects.append(OpenstackProject.factory(self.settings,
-                                                         project,
-                                                         self.version))
+                if limit_projects is None or project['name'] in limit_projects:
+                    projects.append(OpenstackProject.factory(self.settings,
+                                                             project,
+                                                             self.version))
         return projects

--- a/giftwrap/shell.py
+++ b/giftwrap/shell.py
@@ -47,7 +47,8 @@ def build(args):
         with open(args.manifest, 'r') as fh:
             manifest = fh.read()
 
-        buildspec = BuildSpec(manifest, args.version, args.type, args.parallel)
+        buildspec = BuildSpec(manifest, args.version, args.type, args.parallel,
+                              args.projects)
         builder = BuilderFactory.create_builder(args.type, buildspec)
 
         def _signal_handler(*args):
@@ -84,6 +85,7 @@ def main():
                               required=True)
     build_subcmd.add_argument('-s', '--synchronous', dest='parallel',
                               action='store_false')
+    build_subcmd.add_argument('-p', '--projects', nargs='*', dest='projects')
     build_subcmd.set_defaults(func=build)
 
     args = parser.parse_args()

--- a/giftwrap/shell.py
+++ b/giftwrap/shell.py
@@ -85,7 +85,12 @@ def main():
                               required=True)
     build_subcmd.add_argument('-s', '--synchronous', dest='parallel',
                               action='store_false')
-    build_subcmd.add_argument('-p', '--projects', nargs='*', dest='projects')
+
+    def csvarg(arg):
+        if arg is not None:
+            return arg.split(',')
+
+    build_subcmd.add_argument('-p', '--projects', type=csvarg, dest='projects')
     build_subcmd.set_defaults(func=build)
 
     args = parser.parse_args()


### PR DESCRIPTION
New option --projects (-p) allows you to only build certain projects
from the manifest you're using.

Example:

giftwrap build -m examples/manifest.yml -t package -p glance cinder