### PR TITLE
Remove downloadcache in tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,6 @@ deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 commands = nosetests
 sitepackages = False
-downloadcache = {toxworkdir}/_download
 
 [testenv:pep8]
 commands =


### PR DESCRIPTION
The virtualenv doesnt play nice with --download-cache