### PR TITLE
Prep for being in gerrit

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-name = giftwrap
+name = python-giftwrap
 version = 2.1.0
 summary = giftwrap - A tool to build full-stack native system packages.
 description-file =
@@ -14,10 +14,6 @@ classifier =
     License :: OSI Approved :: Apache Software License
     Operating System :: POSIX :: Linux
     Programming Language :: Python
-
-[global]
-setup-hooks =
-    pbr.hooks.setup_hook
 
 [entry_points]
 console_scripts =


### PR DESCRIPTION
name needs to be python-giftwrap for uploads to pypi. Also, the pbr
section in setup.cfg is deprecated.